### PR TITLE
Add Google Sheets pipeline demo

### DIFF
--- a/README_Sheets_API_SV.md
+++ b/README_Sheets_API_SV.md
@@ -1,0 +1,42 @@
+# Google Sheets API – Entreprenörspipeline
+
+Denna demo visar hur du kopplar Python till Google Sheets med `gspread` och `oauth2client` och hur du kan bygga ett enkelt arbetsflöde:
+
+**Leads → Offers → Invoices**
+
+## 1) Skapa Google-projekt + Service Account
+1. Gå till **Google Cloud Console** och skapa ett projekt.
+2. Aktivera **Google Sheets API** och **Google Drive API** för projektet.
+3. Skapa ett **Service Account** under *APIs & Services → Credentials*.
+4. Generera en **JSON-nyckel** (Add Key → Create new key → JSON) och ladda ner filen.
+5. Notera servicekontots e‑postadress.
+
+## 2) Dela ditt kalkylblad
+Skapa eller öppna ett Google Sheet och **dela** det med servicekontots e‑postadress (Editor-rättigheter).
+
+## 3) Lägg in JSON-nyckeln i projektet
+Spara filen som `credentials.json` i projektmappen (byt ut innehållet i den befintliga placeholdern).
+
+## 4) Installera beroenden
+```bash
+pip install -r requirements.txt
+```
+
+## 5) Kör pipeline-demo
+```bash
+python pipeline_demo.py --sheet "DittSheetNamn"
+```
+Skriptet lägger till ett lead, konverterar det till ett offer och därefter en invoice. Därefter skrivs alla steg ut i terminalen.
+
+## Filer
+- `sheets_client.py` – enkel wrapper runt gspread.
+- `pipeline.py` – hanterar logiken för Leads → Offers → Invoices.
+- `pipeline_demo.py` – exempel på hur du använder pipelinen.
+- `credentials.json` – placeholder, ersätt med din riktiga nyckel.
+
+## Vanliga fel
+- **403/404**: Kalkylbladet är inte delat med servicekontot.
+- **Invalid grant**: felaktigt `credentials.json`.
+- **Worksheet not found**: fliken du angav finns inte.
+
+Lycka till!

--- a/credentials.json
+++ b/credentials.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "DITT-PROJEKT-ID",
+  "private_key_id": "BYT-UT",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nBYT-UT\n-----END PRIVATE KEY-----\n",
+  "client_email": "service-konto@DITT-PROJEKT.iam.gserviceaccount.com",
+  "client_id": "BYT-UT",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/service-konto%40DITT-PROJEKT.iam.gserviceaccount.com"
+}

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,0 +1,53 @@
+from typing import List
+from sheets_client import SheetsClient
+
+
+class EntrepreneurPipeline:
+    """Pipeline med tre steg: Leads -> Offers -> Invoices."""
+
+    LEAD_HEADERS = ["id", "namn", "email", "telefon", "status"]
+    OFFER_HEADERS = ["id", "lead_id", "beskrivning", "belopp", "status"]
+    INVOICE_HEADERS = ["id", "offer_id", "belopp", "betald"]
+
+    def __init__(self, credentials: str, spreadsheet: str):
+        self.leads = SheetsClient(credentials, spreadsheet, "Leads")
+        self.offers = SheetsClient(credentials, spreadsheet, "Offers")
+        self.invoices = SheetsClient(credentials, spreadsheet, "Invoices")
+
+        self.leads.ensure_headers(self.LEAD_HEADERS)
+        self.offers.ensure_headers(self.OFFER_HEADERS)
+        self.invoices.ensure_headers(self.INVOICE_HEADERS)
+
+    def add_lead(self, lead_id: str, name: str, email: str = "", phone: str = "") -> None:
+        self.leads.append_row([lead_id, name, email, phone, "lead"])
+
+    def list_leads(self) -> List[List[str]]:
+        return self.leads.read_all()
+
+    def convert_lead_to_offer(self, lead_id: str, offer_id: str, description: str, amount: str) -> None:
+        rows = self.leads.read_all()
+        for i, row in enumerate(rows[1:], start=2):
+            if row[0] == lead_id:
+                self.leads.update_cell(i, self.LEAD_HEADERS.index("status") + 1, "offer")
+                break
+        else:
+            raise ValueError(f"Lead {lead_id} hittades inte")
+
+        self.offers.append_row([offer_id, lead_id, description, amount, "offer"])
+
+    def list_offers(self) -> List[List[str]]:
+        return self.offers.read_all()
+
+    def convert_offer_to_invoice(self, offer_id: str, invoice_id: str, amount: str) -> None:
+        rows = self.offers.read_all()
+        for i, row in enumerate(rows[1:], start=2):
+            if row[0] == offer_id:
+                self.offers.update_cell(i, self.OFFER_HEADERS.index("status") + 1, "invoice")
+                break
+        else:
+            raise ValueError(f"Offer {offer_id} hittades inte")
+
+        self.invoices.append_row([invoice_id, offer_id, amount, "nej"])
+
+    def list_invoices(self) -> List[List[str]]:
+        return self.invoices.read_all()

--- a/pipeline_demo.py
+++ b/pipeline_demo.py
@@ -1,0 +1,22 @@
+import argparse
+from pipeline import EntrepreneurPipeline
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Demo för Entreprenör-pipeline")
+    parser.add_argument("--credentials", default="credentials.json")
+    parser.add_argument("--sheet", required=True, help="Namn på Google Sheet")
+    args = parser.parse_args()
+
+    pipeline = EntrepreneurPipeline(args.credentials, args.sheet)
+    pipeline.add_lead("L1", "Första Lead", "lead@example.com", "0700000000")
+    pipeline.convert_lead_to_offer("L1", "O1", "Webbdesign", "5000")
+    pipeline.convert_offer_to_invoice("O1", "I1", "5000")
+
+    print("Leads:", pipeline.list_leads())
+    print("Offers:", pipeline.list_offers())
+    print("Invoices:", pipeline.list_invoices())
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+gspread
+oauth2client

--- a/sheets_client.py
+++ b/sheets_client.py
@@ -1,0 +1,49 @@
+from typing import List, Any, Optional
+import gspread
+from oauth2client.service_account import ServiceAccountCredentials
+
+SCOPES = [
+    "https://spreadsheets.google.com/feeds",
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/drive.file",
+]
+
+
+class SheetsClient:
+    """
+    Enkel wrapper runt gspread för att arbeta med en worksheet i ett Google Sheet.
+    """
+
+    def __init__(self, credentials_path: str, spreadsheet_name: str, worksheet_name: str = "Sheet1"):
+        creds = ServiceAccountCredentials.from_json_keyfile_name(credentials_path, SCOPES)
+        self.gc = gspread.authorize(creds)
+        self.sh = self.gc.open(spreadsheet_name)
+        try:
+            self.ws = self.sh.worksheet(worksheet_name)
+        except gspread.WorksheetNotFound:
+            self.ws = self.sh.add_worksheet(title=worksheet_name, rows=100, cols=26)
+
+    def ensure_headers(self, headers: List[str]) -> None:
+        values = self.ws.get_all_values()
+        if not values:
+            self.ws.append_row(headers)
+        else:
+            current = values[0]
+            if current != headers:
+                self.ws.update("A1", [headers])
+
+    def append_row(self, row: List[Any]) -> None:
+        self.ws.append_row(row, value_input_option="USER_ENTERED")
+
+    def read_all(self) -> List[List[str]]:
+        return self.ws.get_all_values()
+
+    def update_cell(self, row: int, col: int, value: Any) -> None:
+        self.ws.update_cell(row, col, value)
+
+    def find_first(self, query: str) -> Optional[gspread.cell.Cell]:
+        try:
+            return self.ws.find(query)
+        except gspread.exceptions.CellNotFound:
+            return None


### PR DESCRIPTION
## Summary
- Add Swedish README explaining how to set up Google Sheets API and run a simple Leads→Offers→Invoices pipeline
- Provide gspread-based `SheetsClient` helper and `EntrepreneurPipeline` for managing pipeline data
- Include runnable demo script and placeholder credentials

## Testing
- `python -m py_compile sheets_client.py pipeline.py pipeline_demo.py`
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68990b10ca648330813e4778ab2ece8f